### PR TITLE
DBG-1: Fix Styles So Debug Toolbar is Shown Over Recent List

### DIFF
--- a/css/toolbar.css
+++ b/css/toolbar.css
@@ -10,6 +10,7 @@
   box-shadow: -1px 1px 6px 1px rgba(0,0,0,0.46);
   font: normal 12px Arial;
   color: #EBF4F7;
+  z-index: 1000;
 }
 
 #da-debug-toolbar .da-toolbar-profile-link {


### PR DESCRIPTION
## Overview
When there si long list of items on recently used list, some links of the toolbar are unable to be used, as the list is shown over the toolbar.

## Before
List of recent items ws rendered above toolbar
![image](https://user-images.githubusercontent.com/21999940/39765008-79293b9e-52a6-11e8-9b99-c83f5b0da88b.png)

## After
Incremented z-index of toolbar so it is shown over recent items.
![image](https://user-images.githubusercontent.com/21999940/39765534-ab3a6e7c-52a7-11e8-9bf4-14ed1e0aa1ae.png)

